### PR TITLE
Use powershell instead of cmd setx

### DIFF
--- a/src/EnvMan/Properties/AssemblyInfo.cs
+++ b/src/EnvMan/Properties/AssemblyInfo.cs
@@ -38,9 +38,9 @@ using System.Runtime.InteropServices;
 // set here build version,
 // use x.x.x.* format for final releases
 // or x.x.x.n format for beta releases
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
-[assembly: AssemblyInformationalVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.1")]
+[assembly: AssemblyFileVersion("2.1.1.1")]
+[assembly: AssemblyInformationalVersion("2.1.1.1")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/EnvManager/Properties/AssemblyInfo.cs
+++ b/src/EnvManager/Properties/AssemblyInfo.cs
@@ -37,9 +37,9 @@ using System.Runtime.InteropServices;
 // set here build version,
 // use x.x.x.* format for final releases
 // or x.x.x.n format for beta releases
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1.0")]
-[assembly: AssemblyInformationalVersion("2.1.1.0")]
+[assembly: AssemblyVersion("2.1.1.1")]
+[assembly: AssemblyFileVersion("2.1.1.1")]
+[assembly: AssemblyInformationalVersion("2.1.1.1")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/EnvManager/Variable/EnvironmentVariableManager.cs
+++ b/src/EnvManager/Variable/EnvironmentVariableManager.cs
@@ -85,7 +85,7 @@ namespace EnvManager.Variable
             ValidateVariables(name, value);
             if (target == EnvironmentVariableTarget.Machine && !IsElevated)
             {
-                File.AppendAllText(cmd_filename, string.Format("SETX {0} \"{1}\" /M\r\n", name, value));
+                File.AppendAllText(cmd_filename, string.Format("[Environment]::SetEnvironmentVariable('{0}','{1}','Machine')\r\n", name, value));
             }
             else
             {
@@ -102,7 +102,7 @@ namespace EnvManager.Variable
         {
             if (target == EnvironmentVariableTarget.Machine && !IsElevated)
             {
-                File.AppendAllText(cmd_filename, string.Format("REG delete \"HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\" /F /V {0}\r\n", name));
+                File.AppendAllText(cmd_filename, string.Format("[Environment]::SetEnvironmentVariable('{0}',$NULL,'Machine')\r\n", name));
             }
             else
             {
@@ -117,14 +117,15 @@ namespace EnvManager.Variable
         {
             if (target == EnvironmentVariableTarget.Machine && !IsElevated)
             {
-                File.Move(cmd_filename, cmd_filename + ".cmd");
-                cmd_filename = cmd_filename + ".cmd";
+                File.Move(cmd_filename, cmd_filename + ".ps1");
+                cmd_filename = cmd_filename + ".ps1";
 
                 Process p = new Process();
-                p.StartInfo = new ProcessStartInfo(cmd_filename)
+                p.StartInfo = new ProcessStartInfo("cmd.exe")
                 {
-                    Verb = "runas",
+                    Verb = "RunAs",
                     UseShellExecute = true,
+                    Arguments = string.Format("/c powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"{0}\"", cmd_filename),
                     WindowStyle = ProcessWindowStyle.Hidden
                 };
                 p.Start();


### PR DESCRIPTION
Even though powershell is being launched through cmd, it is launching a powershell script, which 'escapes' the 1024 per-line character limit, I already tested just to be sure.

The TargetKey SetValue functionality that was added should remain, because it's fundamentally faster than calling an external application, so starting the program up as administrator is good for speed, but it's good to have this as a fallback.