### PR TITLE
Get/Set functions no longer expand variables

### DIFF
--- a/src/EnvMan/Properties/AssemblyInfo.cs
+++ b/src/EnvMan/Properties/AssemblyInfo.cs
@@ -38,9 +38,9 @@ using System.Runtime.InteropServices;
 // set here build version,
 // use x.x.x.* format for final releases
 // or x.x.x.n format for beta releases
-[assembly: AssemblyVersion("2.1.1.1")]
-[assembly: AssemblyFileVersion("2.1.1.1")]
-[assembly: AssemblyInformationalVersion("2.1.1.1")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyInformationalVersion("2.2.0.0")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/EnvManager/EnvManager.cs
+++ b/src/EnvManager/EnvManager.cs
@@ -201,7 +201,7 @@ namespace EnvManager
                     {
                         EnvironmentVariable variable = new EnvironmentVariable();
                         variable.Name = entry.Key.ToString();
-                        variable.Value = entry.Value.ToString();
+                        variable.Value = EnvironmentVariableManager.GetEnvironmentVariable(variable.Name, (EnvironmentVariableTarget)lb.Tag);
                         snapshot.Variables.Add(variable);
                     }
                     if (snapshotManager.AppendSnapshot(snapshot))

--- a/src/EnvManager/Properties/AssemblyInfo.cs
+++ b/src/EnvManager/Properties/AssemblyInfo.cs
@@ -37,9 +37,9 @@ using System.Runtime.InteropServices;
 // set here build version,
 // use x.x.x.* format for final releases
 // or x.x.x.n format for beta releases
-[assembly: AssemblyVersion("2.1.1.1")]
-[assembly: AssemblyFileVersion("2.1.1.1")]
-[assembly: AssemblyInformationalVersion("2.1.1.1")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyInformationalVersion("2.2.0.0")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/EnvManager/Snapshot/EnvironmentSnapshotManager.cs
+++ b/src/EnvManager/Snapshot/EnvironmentSnapshotManager.cs
@@ -46,7 +46,7 @@ namespace EnvManager.Snapshot
             {
                 EnvironmentVariable variable = new EnvironmentVariable();
                 variable.Name = entry.Key.ToString();
-                variable.Value = entry.Value.ToString();
+                variable.Value = EnvironmentVariableManager.GetEnvironmentVariable(variable.Name, usrTarget);
                 usrSnapshot.Variables.Add(variable);
             }
             usrSnapshots.Add(usrSnapshot);
@@ -69,7 +69,7 @@ namespace EnvManager.Snapshot
             {
                 EnvironmentVariable variable = new EnvironmentVariable();
                 variable.Name = entry.Key.ToString();
-                variable.Value = entry.Value.ToString();
+                variable.Value = EnvironmentVariableManager.GetEnvironmentVariable(variable.Name, sysTarget);
                 sysSnapshot.Variables.Add(variable);
             }
             sysSnapshots.Add(sysSnapshot);


### PR DESCRIPTION
I noticed there was a pre-existing `GetEnvironmentVariable` function coded that used direct registry access instead of the Environment library, so I adapted it. It now utilizes the `RegistryValueOptions.DoNotExpandEnvironmentNames` overload parameter to make sure the values it retrieves do not expand. However, for some reason, `Registry.LocalMachine.OpenSubKey` requires administrator _UNLESS_ you're just calling the GetValue method. So I had to circumvent the `TargetKey` function altogether, and I went ahead and eliminated its use elsewhere in the process.

I'm also using the new C# switch case when blocks instead of the if else blocks because they supposedly resolve faster, and I think  they're good for readability as well.

I tested this out quite a bit, hoping I didn't miss anything.

Fixes #9